### PR TITLE
Added the GaussView main directory to PATH

### DIFF
--- a/scitasexternal/packages/gaussian/package.py
+++ b/scitasexternal/packages/gaussian/package.py
@@ -62,6 +62,7 @@ class Gaussian(Package):
             join_path(g16_dir, 'bsd'),
             join_path(g16_dir, 'local'),
             join_path(prefix, 'gv', 'bin')
+            join_path(prefix, 'gv')
         ]
 
         run_env.set('GAUSS_EXEDIR', ':'.join(exec_dirs))


### PR DESCRIPTION
GaussianView has its main binary directly in the root directory of the package, rather than in bin. This directory is not in the PATH of our current Gaussian package, which means gview.sh is not to be foung by normal users. This update corrects this issue and makes the Gaussian module point to GaussView's main directory as well.