### PR TITLE
Corrected a couple of bugs

### DIFF
--- a/scitasexternal/packages/gurobi/package.py
+++ b/scitasexternal/packages/gurobi/package.py
@@ -2,28 +2,12 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install gurobi
-#
-# You can edit this file again by typing:
-#
-#     spack edit gurobi
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
 from spack import *
 
 
 class Gurobi(Package):
-    """Gurobi is the most powerful mathematical optimization solver out there. And our team of PhDs is making it better every day. """
+    """Gurobi is the most powerful mathematical optimization solver out there.
+       And our team of PhDs is making it better every day."""
     homepage = "https://www.gurobi.com"
     url      = "https://packages.gurobi.com/8.1/gurobi8.1.1_linux64.tar.gz"
 
@@ -31,6 +15,14 @@ class Gurobi(Package):
     only_binary = True
 
     version('8.1.1', 'c030414603d88ad122246fe0e42a314fab428222d98e26768480f1f870b53484')
- 
+
+    def url_for_version(self, version):
+        url = "https://packages.gurobi.com/{0}/gurobi{1}_linux64.tar.gz"
+        return url.format(version.up_to(2), version)
+
+    def install(self, spec, prefix):
+        install_tree("linux64", join_path(prefix, "linux64"))
+
     def setup_environment(self, spack_env, run_env):
-        run_env.set('GRB_LICENSE_FILE', join_path(self.prefix,'gurobi.lic'))
+        run_env.prepend_path('PATH', join_path(prefix, 'linux64', 'bin'))
+        run_env.set('GRB_LICENSE_FILE', join_path(prefix, 'linux64', 'gurobi.lic'))


### PR DESCRIPTION
- Added url_for_version because there was an issue downloading the file
- Forced linux64 as the final directory for the gurobi installation. Without this
  it does not work properly (at least when interfaced with Matlab). For more on
  this look at GUROBI_ROOT/linux64/matlab/gurobi_setup.m around line 70.
+ Adjusted the run_env to take the previous modification into account.