### PR TITLE
Adding the latest version of fdtd (2020-R2.4-2502)

### DIFF
--- a/scitasexternal/packages/fdtd/package.py
+++ b/scitasexternal/packages/fdtd/package.py
@@ -33,7 +33,9 @@ class Fdtd(Package):
     licensed = True
     only_binary = True
 
-    version('8.24.2387')
+
+    version('2020-R2.4-2502')
+    version('2020-R2-2387')
     version('8.20.1703')
     version('8.19.1416-1')
     version('8.18.1365-1')


### PR DESCRIPTION
La version 2020-R2-2387 ne sera pas installée. Sauf si demande explicite.